### PR TITLE
Let the users change layouts for modules that have nested names for. ex "Example\MyModule"

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -8,7 +8,7 @@ class Module
         $e->getApplication()->getEventManager()->getSharedManager()->attach('Zend\Mvc\Controller\AbstractActionController', 'dispatch', function($e) {
             $controller      = $e->getTarget();
             $controllerClass = get_class($controller);
-            $moduleNamespace = substr($controllerClass, 0, strpos($controllerClass, '\\'));
+            $moduleNamespace = substr($controllerClass, 0, strpos($controllerClass, '\\Controller'));
             $config          = $e->getApplication()->getServiceManager()->get('config');
             if (isset($config['module_layouts'][$moduleNamespace])) {
                 $controller->layout($config['module_layouts'][$moduleNamespace]);

--- a/Module.php
+++ b/Module.php
@@ -6,13 +6,27 @@ class Module
     public function onBootstrap($e)
     {
         $e->getApplication()->getEventManager()->getSharedManager()->attach('Zend\Mvc\Controller\AbstractController', 'dispatch', function($e) {
-            $controller      = $e->getTarget();
+
+            $controller = $e->getTarget();
             $controllerClass = get_class($controller);
-            $moduleNamespace = substr($controllerClass, 0, strpos($controllerClass, '\\Controller'));
-            $config          = $e->getApplication()->getServiceManager()->get('config');
-            if (isset($config['module_layouts'][$moduleNamespace])) {
-                $controller->layout($config['module_layouts'][$moduleNamespace]);
+            $config = $e->getApplication()->getServiceManager()->get('config');
+
+            if (!isset($config['module_layouts']))
+            {
+                return;
             }
+
+            $moduleLayouts = $config['module_layouts'];
+
+            foreach($moduleLayouts as $moduleNamespace => $layoutName)
+            {
+               if (strpos($controllerClass, $moduleNamespace) === 0)
+               {
+                   $controller->layout($layoutName);
+                   break;
+               }
+            }
+
         }, 100);
     }
 }


### PR DESCRIPTION
Sometimes it is useful to have few modules for some project grouped under one namespace:

MyProject\System
MyProject\Page
MyProject\User

Currently EdpModuleLayouts does not work for such module names:

array(
    'module_layouts' => array(
        'MyProject\System' => 'layout/system-layout', // <--- this won't work
        'MyProject\Page' => 'layout/page-layout', // <--- this won't work either
    ),
);

I've fixed that.
