### PR TITLE
match also with classname

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -8,8 +8,12 @@ class Module
         $e->getApplication()->getEventManager()->getSharedManager()->attach('Zend\Mvc\Controller\AbstractController', 'dispatch', function($e) {
             $controller      = $e->getTarget();
             $controllerClass = get_class($controller);
-            $moduleNamespace = substr($controllerClass, 0, strpos($controllerClass, '\\'));
             $config          = $e->getApplication()->getServiceManager()->get('config');
+            if (isset($config['module_layouts'][$controllerClass])) {
+                $controller->layout($config['module_layouts'][$controllerClass]);
+                return;
+            }
+            $moduleNamespace = substr($controllerClass, 0, strpos($controllerClass, '\\'));
             if (isset($config['module_layouts'][$moduleNamespace])) {
                 $controller->layout($config['module_layouts'][$moduleNamespace]);
             }

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,24 @@
 {
-    "name": "evandotpro/edp-module-layouts",
-    "description": "EdpModuleLayouts is very simple ZF2 module for making module-specific layouts insanely easy.",
-    "type": "library",
-    "keywords": [
-        "zf2"
-    ],
-    "homepage": "https://github.com/EvanDotPro/EdpModuleLayouts",
-    "authors": [
-        {
-            "name": "Evan Coury",
-            "email": "me@evancoury.com",
-            "homepage": "http://blog.evan.pro/"
-        }
-    ],
-    "require": {
-        "php": ">=5.3"
+    "name" : "ixtec/edp-module-layouts",
+    "description" : "EdpModuleLayouts is very simple ZF2 module for making module-specific layouts insanely easy.",
+    "require" : {
+        "php" : ">=5.3"
     },
-    "autoload": {
-        "classmap": [
-            "./Module.php"
-        ]
-    }
+    "authors" : [ 
+        {
+            "name" : "Evan Coury",
+            "email" : "me@evancoury.com",
+            "homepage" : "http://blog.evan.pro/"
+        }, {
+            "name" : "Oliver Konig",
+            "email" : "ixtec.io@gmail.com",
+            "homepage" : "http://ixtec.io/"
+        } 
+  ],
+  "keywords" : [ "zf2" ],
+  "autoload" : {
+    "classmap" : [ "./Module.php" ]
+  },
+  "type" : "library",
+  "homepage" : "https://github.com/ixtec/EdpModuleLayouts"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,22 @@
 {
-    "name" : "ixtec/edp-module-layouts",
+    "name" : "ixtec/EdpModuleLayouts",
     "description" : "EdpModuleLayouts is very simple ZF2 module for making module-specific layouts insanely easy.",
     "require" : {
         "php" : ">=5.3"
     },
-    "authors" : [ 
-        {
-            "name" : "Evan Coury",
-            "email" : "me@evancoury.com",
-            "homepage" : "http://blog.evan.pro/"
-        }, {
-            "name" : "Oliver Konig",
-            "email" : "ixtec.io@gmail.com",
-            "homepage" : "http://ixtec.io/"
-        } 
-  ],
-  "keywords" : [ "zf2" ],
-  "autoload" : {
-    "classmap" : [ "./Module.php" ]
-  },
-  "type" : "library",
-  "homepage" : "https://github.com/ixtec/EdpModuleLayouts"
+    "authors" : [{
+        "name" : "Evan Coury",
+        "email" : "me@evancoury.com",
+        "homepage" : "http://blog.evan.pro/"
+    }, {
+        "name" : "Oliver Konig",
+        "email" : "ixtec.io@gmail.com",
+        "homepage" : "http://ixtec.io/"
+    }],
+    "keywords" : [ "zf2" ],
+    "autoload" : {
+        "classmap" : [ "./Module.php" ]
+    },
+    "type" : "library",
+    "homepage" : "https://github.com/ixtec/EdpModuleLayouts"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name" : "ixtec/EdpModuleLayouts",
+    "name" : "ixtec/edp-module-layouts",
     "description" : "EdpModuleLayouts is very simple ZF2 module for making module-specific layouts insanely easy.",
     "require" : {
         "php" : ">=5.3"


### PR DESCRIPTION
allows to specify a classname in config, for assigning individual layouts also to individual controllers, example:
    'module_layouts' => array(
        'User' => 'user/layout', // working
        'User\Controller\IndexController' => 'user/index/layout', // working, too
    ),
